### PR TITLE
Change the sequence of VisibilityDistanceType.

### DIFF
--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -151,11 +151,9 @@ struct CreatureInfo
     uint32  TrainerTemplateId;
     uint32  VendorTemplateId;
     uint32  GossipMenuId;
-    // fix z2742 visibility
     VisibilityDistanceType visibilityDistanceType;
     uint32  EquipmentTemplateId;
     uint32  civilian;
-    VisibilityDistanceType visibilityDistanceType;
     char const* AIName;
     uint32  ScriptID;
 


### PR DESCRIPTION
struct CreatureInfo: 
Move the member 
VisibilityDistanceType visibilityDistanceType; 
in front of  
uint32  EquipmentTemplateId;

Fix z2742 visibility update. 
This misplaced sequence will cause a wrong data filling during sStorageCreature initialization 
which makes creature's EquipmentId get a wrong value in the game.

